### PR TITLE
removes xml specific version dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   meta: ^1.1.5
   crypto: ^2.0.6
   http: ^0.12.0
-  xml: ^3.0.1
+  xml:
 
 dev_dependencies:
   test: ^1.0.0


### PR DESCRIPTION
Hi,

First of all thanx for publishing this package, and is working pretty much fine but your xml dependency is quite outdated.
This change will basically remove the dependency bar from the `xml`
Did this change cuz `flutter_svg` requires a higher version of `xml` and downgrading `flutter_svg` was creating some other issues as well